### PR TITLE
fixed a bug when writing nodevaluelistlists

### DIFF
--- a/src/dna/series/lists/NodeValueListList.java
+++ b/src/dna/series/lists/NodeValueListList.java
@@ -23,7 +23,7 @@ public class NodeValueListList extends List<NodeValueList> {
 
 	public void write(String dir) throws IOException {
 		for (NodeValueList n : this.getList()) {
-			n.write(dir, Files.getDistributionFilename(n.getName()));
+			n.write(dir, Files.getNodeValueListFilename(n.getName()));
 		}
 	}
 


### PR DESCRIPTION
.distribution suffix was written vor nodevaluelists, which caused the
aggregation to not be able to read nodevaluelists resulting in a
nullpointer exception when accessing values
