### PR TITLE
added a config-field to set the name of video-files

### DIFF
--- a/config/vis/graph.properties
+++ b/config/vis/graph.properties
@@ -108,6 +108,8 @@ GRAPH_VIS_VIDEO_DEFAULT_RECORDING_FPS = 15
 GRAPH_VIS_VIDEO_MAXIMUM_LENGTH_IN_SECONDS = 300
 GRAPH_VIS_VIDEO_DIR = videos/
 GRAPH_VIS_VIDEO_SUFFIX = .avi
+# default = null -> name will be generated automatically
+GRAPH_VIS_VIDEO_FILENAME = null
 
 # if true, video images will be buffered on filesystem during record
 GRAPH_VIS_VIDEO_BUFFER_IMAGES_ON_FILESYSTEM = true

--- a/src/dna/visualization/VisualizationUtils.java
+++ b/src/dna/visualization/VisualizationUtils.java
@@ -355,6 +355,9 @@ public class VisualizationUtils {
 		DateFormat df = new SimpleDateFormat("yyyy_MM_dd-HH_mm_ss");
 		String filename = name + "-" + df.format(new Date());
 
+		if (!Config.get("GRAPH_VIS_VIDEO_FILENAME").equals("null"))
+			return dir + Config.get("GRAPH_VIS_VIDEO_FILENAME") + suffix;
+
 		// get name
 		File file = new File(dir + filename + suffix);
 		int id = 0;


### PR DESCRIPTION
- by default it is set to null and names will be generated automatically
with the components name and a timestamp
- if it is set to some other value than null, this value will be taken
as the videos name